### PR TITLE
Correctly implement mapToEscCommand for type text (iOS)

### DIFF
--- a/ios/Classes/BluetoothPrintPlugin.h
+++ b/ios/Classes/BluetoothPrintPlugin.h
@@ -11,3 +11,12 @@
 @interface BluetoothPrintStreamHandler : NSObject<FlutterStreamHandler>
 @property FlutterEventSink sink;
 @end
+
+typedef enum NSUInteger {
+    CharacterSizeEnumDefault = 0,
+    CharacterSizeEnumDoubleHeight = 2,
+    CharacterSizeEnumDoubleWidth = 16,
+    PrintModeEnumDefault = 0,
+    PrintModeEnumBold = 8,
+    PrintModeEnumUnderline = 128
+}TextTypeEnum;

--- a/ios/Classes/BluetoothPrintPlugin.m
+++ b/ios/Classes/BluetoothPrintPlugin.m
@@ -201,9 +201,21 @@
         [command addSetJustification:[align intValue]];
         
         if([@"text" isEqualToString:type]){
-            [command addPrintMode: [weight intValue] ==0?0:0|8|16|32];
+            
+            Byte mode = PrintModeEnumDefault;
+            if ([weight intValue] == 1) mode = mode | PrintModeEnumBold;
+            if ([underline intValue] == 1) mode = mode | PrintModeEnumUnderline;
+            [command addPrintMode: mode];
+
+            Byte size = CharacterSizeEnumDefault;
+            if ([height intValue] == 1) size = size | CharacterSizeEnumDoubleHeight;
+            if ([width intValue] == 1) size = size | CharacterSizeEnumDoubleWidth;
+            [command addSetCharcterSize: size];
+            
             [command addText:content];
-            [command addPrintMode: 0];
+            [command addPrintMode: PrintModeEnumDefault];
+            [command addSetCharcterSize: CharacterSizeEnumDefault];
+
         }else if([@"barcode" isEqualToString:type]){
             [command addSetBarcodeWidth:2];
             [command addSetBarcodeHeight:60];

--- a/ios/Classes/EscCommand.h
+++ b/ios/Classes/EscCommand.h
@@ -51,8 +51,15 @@
 /**
  * 方法说明：设置打印模式，0x1B 0x21 n(0-255)，根据n的值设置字符打印模式
  *@param n 二进制默认为00000000(0X0),10001000(0X88)表示下划线和加粗，00001000(0X08)表示加粗，10000000(0X80)表示下划线
+ *
+ * Set the print mode, where n can be either:
+ *   0   (00000000) means default
+ *   8   (00001000) means bold
+ *   128 (10000000) means underline
+ *   136 (10001000) means underline and bold
  */
 -(void) addPrintMode:(int) n;
+
 /**
  * 方法说明：设置国际字符集，默认为美国0
  * @param n 字符集编号
@@ -101,6 +108,12 @@
 /**
  * 方法说明：设置字符放大，限制为不放大和放大2倍，n=0x11
  * @param n = width | height 宽度放大倍数，0 ≤n ≤255 （1 ≤ 纵向放大倍数 ≤8，1 ≤ 横向放达倍数 ≤8）[描述]   用0 到2 位选择字符高度，4 到7 位选择字符宽度
+ *
+ * Set character size, where n can be either:
+ *   0  (0000) means default
+ *   2  (0010) means double height
+ *   16 (1000) means double width
+ *   18 (1010) means double height and width
  */
 -(void) addSetCharcterSize:(int) n;
 


### PR DESCRIPTION
Fixes #24 
Fixes #31 

![fixed-receipt-text](https://user-images.githubusercontent.com/4117210/144708681-6e1629ba-1a03-4cd1-9e08-b530f253d75d.jpeg)

To achieve the above results, use the following and will work on both Android and iOS:

```
List<LineText> list = [];

list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 1, width: 1, height: 1, underline: 1, content: 'ANDROID'));
list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, content: ''));

list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 0, width: 0, height: 0, underline: 0, content: 'normal'));
list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 1, width: 0, height: 0, underline: 0, content: 'bold'));
list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 0, width: 0, height: 0, underline: 1, content: 'underline'));
list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 1, width: 0, height: 0, underline: 1, content: 'bold underline'));

list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 0, width: 0, height: 1, underline: 0, content: 'tall'));
list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 0, width: 1, height: 0, underline: 0, content: 'wide'));
list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 0, width: 1, height: 1, underline: 0, content: 'tall wide'));

list.add(LineText(type: LineText.TYPE_TEXT, linefeed: 1, weight: 1, width: 1, height: 1, underline: 1, content: 'everything!'));
```

