### PR TITLE
Expose mapToEscCommand and mapToTscCommand to bypass Bluetooth operations

### DIFF
--- a/android/src/main/java/com/example/bluetooth_print/BluetoothPrintPlugin.java
+++ b/android/src/main/java/com/example/bluetooth_print/BluetoothPrintPlugin.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Vector;
 
 /** BluetoothPrintPlugin */
 public class BluetoothPrintPlugin implements FlutterPlugin, ActivityAware, MethodCallHandler, RequestPermissionsResultListener {
@@ -199,6 +200,12 @@ public class BluetoothPrintPlugin implements FlutterPlugin, ActivityAware, Metho
         break;
       case "destroy":
         result.success(destroy());
+        break;
+      case "mapToEscCommand":
+        mapTo(PrintType.RECEIPT, result, args);
+        break;
+      case "mapToTscCommand":
+        mapTo(PrintType.LABEL, result, args);
         break;
       case "print":
         print(result, args);
@@ -423,6 +430,37 @@ public class BluetoothPrintPlugin implements FlutterPlugin, ActivityAware, Metho
     }
 
   }
+  
+  private void mapTo(PrintType printType, Result result, Map<String, Object> args) {
+
+    if (args.containsKey("config") && args.containsKey("data")) {
+      final Map<String,Object> config = (Map<String,Object>)args.get("config");
+      final List<Map<String,Object>> list = (List<Map<String,Object>>)args.get("data");
+      if (list == null) return;
+
+      Vector<Byte> bytes = new Vector();
+      switch (printType) {
+        case RECEIPT: 
+          bytes = PrintContent.mapToReceipt(config, list);
+          break;
+        case LABEL: 
+          bytes = PrintContent.mapToLabel(config, list);
+          break;
+        default:
+          return;
+      }
+  
+      // Convert Vector<Byte> to List<Integer> - there must be a simpler way 
+      List<Integer> ints = new ArrayList();
+      for (Byte b : bytes) {
+        ints.add(b.intValue());
+      }
+
+      result.success(ints);
+    } else{
+      result.error("please add config or data", "", null);
+    }
+  }
 
   @Override
   public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
@@ -481,3 +519,5 @@ public class BluetoothPrintPlugin implements FlutterPlugin, ActivityAware, Metho
   };
 
 }
+
+enum PrintType { RECEIPT, LABEL }

--- a/ios/Classes/BluetoothPrintPlugin.m
+++ b/ios/Classes/BluetoothPrintPlugin.m
@@ -104,6 +104,20 @@
      } @catch(FlutterError *e) {
        result(e);
      }
+  } else if([@"mapToEscCommand" isEqualToString:call.method]) {
+       @try {
+         NSDictionary *args = [call arguments];
+         result([self mapToEscCommand:args]);
+       } @catch(FlutterError *e) {
+         result(e);
+       }
+  } else if([@"mapToTscCommand" isEqualToString:call.method]) {
+       @try {
+         NSDictionary *args = [call arguments];
+         result([self mapToTscCommand:args]);
+       } @catch(FlutterError *e) {
+         result(e);
+       }
   } else if([@"printReceipt" isEqualToString:call.method]) {
        @try {
          NSDictionary *args = [call arguments];


### PR DESCRIPTION
Currently it is not possible to generate the raw data required to send to the device without having first established a connection. 

As I am unable to connect to a BLE (type 2) device, I am now using [flutter_blue](https://pub.dev/packages/flutter_blue) to successfully establish the connection instead. I then call `mapToEscCommand` to create the raw data before passing it to the device. 

This eliminates the need to convert any existing receipt creation logic using [LineText](https://github.com/thon-ju/bluetooth_print/blob/master/lib/bluetooth_print_model.dart) with [esc_pos_utils](https://pub.dev/packages/esc_pos_utils)

The longterm goal is to migrate fully to [esc_pos_utils](https://pub.dev/packages/esc_pos_utils) using an adapter - watch this space